### PR TITLE
Add UnitController with basic combat handling

### DIFF
--- a/Assets/Scripts/HealthComponent.cs
+++ b/Assets/Scripts/HealthComponent.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple health handler for units.
+/// </summary>
+public class HealthComponent : MonoBehaviour
+{
+    public int maxHealth = 100;
+    public int currentHealth;
+
+    public bool IsAlive => currentHealth > 0;
+
+    public delegate void DeathHandler();
+    public event DeathHandler OnDeath;
+
+    private void Awake()
+    {
+        currentHealth = maxHealth;
+    }
+
+    public void ApplyDamage(int amount)
+    {
+        if (!IsAlive)
+            return;
+
+        currentHealth -= amount;
+        if (currentHealth <= 0)
+        {
+            currentHealth = 0;
+            OnDeath?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/HealthComponent.cs.meta
+++ b/Assets/Scripts/HealthComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8953d4baa934f7ea31cd16f496bf114
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UnitAIController.cs
+++ b/Assets/Scripts/UnitAIController.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+/// <summary>
+/// Placeholder AI controller for units.
+/// </summary>
+[RequireComponent(typeof(NavMeshAgent))]
+public class UnitAIController : MonoBehaviour
+{
+    private NavMeshAgent agent;
+    private UnitController unit;
+
+    private void Awake()
+    {
+        agent = GetComponent<NavMeshAgent>();
+        unit = GetComponent<UnitController>();
+    }
+
+    private void Update()
+    {
+        // Basic follow behavior in formation
+        if (unit != null && unit.agent != null && unit.IsInFormationMode())
+        {
+            agent.SetDestination(unit.assignedFormationPosition);
+        }
+    }
+}

--- a/Assets/Scripts/UnitAIController.cs.meta
+++ b/Assets/Scripts/UnitAIController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8225f67f42b4e0380a9056aaf89987e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UnitController.cs
+++ b/Assets/Scripts/UnitController.cs
@@ -1,0 +1,70 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+/// <summary>
+/// Controls an individual unit in combat.
+/// </summary>
+[RequireComponent(typeof(NavMeshAgent))]
+[RequireComponent(typeof(HealthComponent))]
+[RequireComponent(typeof(UnitAIController))]
+public class UnitController : MonoBehaviour
+{
+    public enum UnitState { Inactive, Active, InCombat }
+
+    [HideInInspector] public Vector3 assignedFormationPosition;
+    [HideInInspector] public bool isAlive = true;
+
+    public NavMeshAgent agent { get; private set; }
+    public UnitAIController ai { get; private set; }
+    public HealthComponent health { get; private set; }
+
+    private UnitState currentState = UnitState.Inactive;
+    private bool formationMode = false;
+
+    public delegate void UnitDeathHandler(UnitController unit);
+    public event UnitDeathHandler OnDeath;
+
+    private void Awake()
+    {
+        agent = GetComponent<NavMeshAgent>();
+        ai = GetComponent<UnitAIController>();
+        health = GetComponent<HealthComponent>();
+    }
+
+    private void Update()
+    {
+        if (formationMode && currentState == UnitState.Active)
+        {
+            agent.SetDestination(assignedFormationPosition);
+        }
+    }
+
+    public void SetState(UnitState newState)
+    {
+        currentState = newState;
+    }
+
+    public void SetFormationMode(bool enable)
+    {
+        formationMode = enable;
+    }
+
+    public bool IsInFormationMode()
+    {
+        return formationMode;
+    }
+
+    public void ApplyDamage(int amount)
+    {
+        if (health != null)
+        {
+            health.ApplyDamage(amount);
+            if (!health.IsAlive && isAlive)
+            {
+                isAlive = false;
+                agent.isStopped = true;
+                OnDeath?.Invoke(this);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UnitController.cs.meta
+++ b/Assets/Scripts/UnitController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30ab16256fd9456197d2ccec0dd2f05f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- implement `UnitController` to manage unit state, formation movement and death events
- add simple `HealthComponent` for HP tracking
- create placeholder `UnitAIController` for formation following

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685517cb0ab88332afbcb50d6a51797d