### PR TITLE
Add combat damage system

### DIFF
--- a/Assets/Scripts/Combat.meta
+++ b/Assets/Scripts/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d668206a-b424-4690-8a7f-2ff7075cfbdc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Collider))]
+public class CombatController : MonoBehaviour
+{
+    public CombatStats combatStats;
+
+    public delegate void HitEvent(GameObject target, int damage);
+    public event HitEvent OnHit;
+
+    private void Reset()
+    {
+        // Ensure collider is a trigger
+        Collider col = GetComponent<Collider>();
+        if (col != null)
+        {
+            col.isTrigger = true;
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        DefenseStats defense = other.GetComponent<DefenseStats>();
+        HealthComponent health = other.GetComponent<HealthComponent>();
+        if (defense == null || health == null)
+            return;
+
+        int damage = DamageCalculator.CalculateDamage(combatStats, defense);
+        health.ApplyDamage(damage);
+        OnHit?.Invoke(other.gameObject, damage);
+    }
+}

--- a/Assets/Scripts/Combat/CombatController.cs.meta
+++ b/Assets/Scripts/Combat/CombatController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: edffef63-aece-450d-a327-344735bad4b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/CombatStats.cs
+++ b/Assets/Scripts/Combat/CombatStats.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+[System.Serializable]
+public class CombatStats
+{
+    [Min(0)]
+    public int baseDamage = 10;
+    public DamageType damageType = DamageType.Slashing;
+    [Range(0f, 1f)]
+    public float penetration = 0f; // percentage reducing enemy resistance
+}

--- a/Assets/Scripts/Combat/CombatStats.cs.meta
+++ b/Assets/Scripts/Combat/CombatStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec06a43c-c492-408f-a9a8-f9f5e33b9716
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/DamageCalculator.cs
+++ b/Assets/Scripts/Combat/DamageCalculator.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+public static class DamageCalculator
+{
+    public static int CalculateDamage(CombatStats attacker, DefenseStats defender)
+    {
+        if (attacker == null || defender == null)
+            return 0;
+
+        float resistance = 0f;
+        switch (attacker.damageType)
+        {
+            case DamageType.Slashing:
+                resistance = defender.slashingResistance;
+                break;
+            case DamageType.Piercing:
+                resistance = defender.piercingResistance;
+                break;
+            case DamageType.Blunt:
+                resistance = defender.bluntResistance;
+                break;
+        }
+
+        float mitigated = Mathf.Clamp01(resistance - attacker.penetration);
+        float finalMultiplier = 1f - mitigated;
+        int finalDamage = Mathf.Max(Mathf.RoundToInt(attacker.baseDamage * finalMultiplier), 0);
+        return finalDamage;
+    }
+}

--- a/Assets/Scripts/Combat/DamageCalculator.cs.meta
+++ b/Assets/Scripts/Combat/DamageCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 816119ef-5445-4b07-bf78-d1eba54460df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/DamageType.cs
+++ b/Assets/Scripts/Combat/DamageType.cs
@@ -1,0 +1,6 @@
+public enum DamageType
+{
+    Slashing,
+    Piercing,
+    Blunt
+}

--- a/Assets/Scripts/Combat/DamageType.cs.meta
+++ b/Assets/Scripts/Combat/DamageType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ed770c1-5840-488d-9e19-a3ea195c6bee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/DefenseStats.cs
+++ b/Assets/Scripts/Combat/DefenseStats.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[System.Serializable]
+public class DefenseStats : MonoBehaviour
+{
+    [Range(0f, 1f)]
+    public float slashingResistance = 0f;
+    [Range(0f, 1f)]
+    public float piercingResistance = 0f;
+    [Range(0f, 1f)]
+    public float bluntResistance = 0f;
+}

--- a/Assets/Scripts/Combat/DefenseStats.cs.meta
+++ b/Assets/Scripts/Combat/DefenseStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59462a3e-9c37-49d2-8b7a-8f715a816dc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UnitController.cs
+++ b/Assets/Scripts/UnitController.cs
@@ -6,6 +6,7 @@ using UnityEngine.AI;
 /// </summary>
 [RequireComponent(typeof(NavMeshAgent))]
 [RequireComponent(typeof(HealthComponent))]
+[RequireComponent(typeof(DefenseStats))]
 [RequireComponent(typeof(UnitAIController))]
 public class UnitController : MonoBehaviour
 {
@@ -17,6 +18,7 @@ public class UnitController : MonoBehaviour
     public NavMeshAgent agent { get; private set; }
     public UnitAIController ai { get; private set; }
     public HealthComponent health { get; private set; }
+    public DefenseStats defense { get; private set; }
 
     private UnitState currentState = UnitState.Inactive;
     private bool formationMode = false;
@@ -29,6 +31,7 @@ public class UnitController : MonoBehaviour
         agent = GetComponent<NavMeshAgent>();
         ai = GetComponent<UnitAIController>();
         health = GetComponent<HealthComponent>();
+        defense = GetComponent<DefenseStats>();
 
         if (health != null)
         {


### PR DESCRIPTION
## Summary
- add Combat scripts for calculating damage by type
- handle resistance and penetration
- detect hits and apply damage via CombatController
- extend UnitController to require DefenseStats

## Testing
- `ls Tests 2>/dev/null || echo 'no tests'`

------
https://chatgpt.com/codex/tasks/task_e_685565e42e54833291fcf3dea185d8ee