### PR TITLE
Implement unit death event handling in FormationController

### DIFF
--- a/Assets/Scripts/FormationController.cs
+++ b/Assets/Scripts/FormationController.cs
@@ -16,7 +16,7 @@ public class FormationController : MonoBehaviour
     public Transform leaderTransform;
 
     // Active members of the squad
-    private readonly List<UnitController> units = new List<UnitController>();
+    private readonly List<UnitController> units = new();
 
     private void Update()
     {
@@ -32,6 +32,7 @@ public class FormationController : MonoBehaviour
             return;
 
         units.Add(unit);
+        unit.OnDeath += OnUnitDeath;
         ReassignPositions();
     }
 
@@ -45,6 +46,7 @@ public class FormationController : MonoBehaviour
 
         if (units.Remove(unit))
         {
+            unit.OnDeath -= OnUnitDeath;
             ReassignPositions();
         }
     }
@@ -97,8 +99,16 @@ public class FormationController : MonoBehaviour
     /// <summary>
     /// Reassigns slots when the formation changes or units are added/removed.
     /// </summary>
-    private void ReassignPositions()
+    public void ReassignPositions()
     {
         UpdateFormationPositions();
+    }
+
+    /// <summary>
+    /// Callback when a unit dies to keep formation cohesion.
+    /// </summary>
+    public void OnUnitDeath(UnitController unit)
+    {
+        UnregisterUnit(unit);
     }
 }


### PR DESCRIPTION
## Summary
- allow FormationController to update formation when units die
- subscribe to each unit's OnDeath event
- expose ReassignPositions for external calls

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685694bea53c8332ae752958571d4765