### PR TITLE
Add feedback to SquadCommandSystem

### DIFF
--- a/Assets/Scripts/HeroInputController.cs
+++ b/Assets/Scripts/HeroInputController.cs
@@ -92,13 +92,13 @@ public class HeroInputController : MonoBehaviour
             return;
 
         if (Input.GetKeyDown(KeyCode.Alpha1))
-            commandSystem.IssueCommand(SquadCommandSystem.CommandType.FollowMe);
+            commandSystem.IssueCommand(SquadCommandSystem.SquadCommand.Follow);
 
         if (Input.GetKeyDown(KeyCode.Alpha2))
-            commandSystem.IssueCommand(SquadCommandSystem.CommandType.HoldPosition);
+            commandSystem.IssueCommand(SquadCommandSystem.SquadCommand.HoldPosition);
 
         if (Input.GetKeyDown(KeyCode.Alpha3) && currentTarget != null)
-            commandSystem.IssueCommand(SquadCommandSystem.CommandType.AttackTarget, currentTarget);
+            commandSystem.IssueCommand(SquadCommandSystem.SquadCommand.AttackTarget, currentTarget);
 
         if (Input.GetKeyDown(KeyCode.Tab))
             onFormationMenu?.Invoke();

--- a/Assets/Scripts/Squads/SquadCommandSystem.cs
+++ b/Assets/Scripts/Squads/SquadCommandSystem.cs
@@ -1,27 +1,31 @@
 using UnityEngine;
 using System.Collections.Generic;
+using TMPro;
 
 /// <summary>
 /// Allows the player to issue basic commands to the active squad.
 /// </summary>
 public class SquadCommandSystem : MonoBehaviour
 {
-    public enum CommandType
+    public enum SquadCommand
     {
-        FollowMe,
+        Follow,
         HoldPosition,
         AttackTarget
     }
 
-    [Tooltip("Reference to the squad manager handling the active squad")] 
+    [Tooltip("Reference to the squad manager handling the active squad")]
     public SquadManager squadManager;
+
+    [Tooltip("Optional text element to display issued commands")]
+    public TMP_Text feedbackText;
 
     /// <summary>
     /// Sends a command to every unit in the active squad.
     /// </summary>
     /// <param name="command">Type of command to issue.</param>
     /// <param name="target">Optional target transform used for AttackTarget.</param>
-    public void IssueCommand(CommandType command, Transform target = null)
+    public void IssueCommand(SquadCommand command, Transform target = null)
     {
         if (squadManager == null)
             squadManager = SquadManager.Instance;
@@ -44,17 +48,17 @@ public class SquadCommandSystem : MonoBehaviour
 
             switch (command)
             {
-                case CommandType.FollowMe:
+                case SquadCommand.Follow:
                     unit.SetFormationMode(true);
                     ai.SetFollowMode(true);
                     ai.ForceState(UnitAIController.AIState.MovingToFormation);
                     break;
-                case CommandType.HoldPosition:
+                case SquadCommand.HoldPosition:
                     unit.SetFormationMode(false);
                     ai.SetFollowMode(false);
                     ai.ForceState(UnitAIController.AIState.Idle);
                     break;
-                case CommandType.AttackTarget:
+                case SquadCommand.AttackTarget:
                     if (target != null)
                     {
                         ai.SetTarget(target);
@@ -62,5 +66,14 @@ public class SquadCommandSystem : MonoBehaviour
                     break;
             }
         }
+
+        ShowFeedback($"Issued command: {command}");
+    }
+
+    private void ShowFeedback(string message)
+    {
+        if (feedbackText != null)
+            feedbackText.text = message;
+        Debug.Log(message);
     }
 }


### PR DESCRIPTION
## Summary
- implement `SquadCommandSystem` enum `SquadCommand`
- add optional text feedback and debug log for issued commands
- update input logic to use new enum

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c43cbb1083328bc82f57f008be32