### PR TITLE
Add modular PreparationPanel UI

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -66,6 +66,16 @@
     <Compile Include="Assets\Scripts\UnitAIController.cs" />
     <Compile Include="Assets\Scripts\HealthComponent.cs" />
     <Compile Include="Assets\Scripts\PlayerMovement.cs" />
+    <Compile Include="Assets\Scripts/Game/PlayerData.cs" />
+    <Compile Include="Assets\Scripts/Game/CharacterData.cs" />
+    <Compile Include="Assets\Scripts/Game/PerkData.cs" />
+    <Compile Include="Assets\Scripts/Game/PlayerProfileManager.cs" />
+    <Compile Include="Assets\Scripts/Game/GameManager.cs" />
+    <Compile Include="Assets\Scripts/UI/SelectSquadPanel.cs" />
+    <Compile Include="Assets\Scripts/UI/PerkEntryUI.cs" />
+    <Compile Include="Assets\Scripts/UI/PerkPreviewPanel.cs" />
+    <Compile Include="Assets\Scripts/UI/HeroViewerPanel.cs" />
+    <Compile Include="Assets\Scripts/UI/PreparationPanel.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\Mirror\Plugins\Mono.Cecil\Mono.CecilX.dll" />

--- a/Assets/Scripts/Game/CharacterData.cs
+++ b/Assets/Scripts/Game/CharacterData.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Data describing a hero character used by the player.
+/// </summary>
+[CreateAssetMenu(fileName = "NewCharacterData", menuName = "Characters/Character Data")]
+public class CharacterData : ScriptableObject
+{
+    public GameObject modelPrefab;
+    public int health;
+    public int attack;
+    public int defense;
+    public List<PerkData> passivePerks = new();
+}

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+/// <summary>
+/// Simplified game manager with helper methods used from UI.
+/// </summary>
+public static class GameManager
+{
+    /// <summary>
+    /// Spawns a squad using the global SquadManager instance.
+    /// </summary>
+    public static void SpawnSquad(SquadLoadout loadout)
+    {
+        if (loadout == null)
+        {
+            Debug.LogWarning("SpawnSquad called with null loadout");
+            return;
+        }
+
+        var manager = SquadManager.Instance;
+        if (manager != null)
+        {
+            manager.SpawnSquadFromLoadoutAt(loadout, manager.defaultSpawnPoint.position);
+        }
+        else
+        {
+            Debug.LogWarning("No SquadManager instance found");
+        }
+    }
+}

--- a/Assets/Scripts/Game/PerkData.cs
+++ b/Assets/Scripts/Game/PerkData.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// Basic perk information used for display purposes.
+/// </summary>
+[CreateAssetMenu(fileName = "NewPerkData", menuName = "Characters/Perk")]
+public class PerkData : ScriptableObject
+{
+    public Sprite icon;
+    public string perkName;
+    [TextArea] public string description;
+}

--- a/Assets/Scripts/Game/PlayerData.cs
+++ b/Assets/Scripts/Game/PlayerData.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Container with basic information about the player profile.
+/// </summary>
+[System.Serializable]
+public class PlayerData
+{
+    public CharacterData activeCharacter;
+    public List<SquadLoadout> unlockedSquads = new();
+}

--- a/Assets/Scripts/Game/PlayerProfileManager.cs
+++ b/Assets/Scripts/Game/PlayerProfileManager.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Manages the current player's profile in memory.
+/// Provides quick access to character and squad data.
+/// </summary>
+public static class PlayerProfileManager
+{
+    public static PlayerData CurrentProfile { get; private set; }
+
+    public static void Initialize(PlayerData data)
+    {
+        CurrentProfile = data;
+    }
+
+    public static CharacterData GetActiveCharacter() => CurrentProfile?.activeCharacter;
+
+    public static List<SquadLoadout> GetUnlockedSquads() =>
+        CurrentProfile != null ? CurrentProfile.unlockedSquads : new List<SquadLoadout>();
+}

--- a/Assets/Scripts/UI/HeroViewerPanel.cs
+++ b/Assets/Scripts/UI/HeroViewerPanel.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Shows the active hero model and its stats.
+/// </summary>
+public class HeroViewerPanel : MonoBehaviour
+{
+    public RawImage heroImage;
+    public RenderTexture renderTexture;
+    public Text statsText;
+
+    private GameObject modelInstance;
+    private Camera renderCamera;
+
+    /// <summary>
+    /// Loads the hero model and stats from the given data.
+    /// </summary>
+    public void LoadHero(CharacterData data)
+    {
+        if (data == null)
+            return;
+
+        if (heroImage != null && renderTexture != null)
+            heroImage.texture = renderTexture;
+
+        if (modelInstance != null)
+            Destroy(modelInstance);
+        if (renderCamera != null)
+            Destroy(renderCamera.gameObject);
+
+        if (data.modelPrefab != null)
+        {
+            modelInstance = Instantiate(data.modelPrefab);
+            modelInstance.transform.position = Vector3.zero;
+            renderCamera = new GameObject("HeroRenderCam").AddComponent<Camera>();
+            renderCamera.transform.position = modelInstance.transform.position + new Vector3(0, 1, -2);
+            renderCamera.transform.LookAt(modelInstance.transform);
+            renderCamera.targetTexture = renderTexture;
+        }
+
+        if (statsText != null)
+            statsText.text = $"HP: {data.health}\nATK: {data.attack}\nDEF: {data.defense}";
+    }
+}

--- a/Assets/Scripts/UI/PerkEntryUI.cs
+++ b/Assets/Scripts/UI/PerkEntryUI.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Helper component to display a single perk in the UI.
+/// </summary>
+public class PerkEntryUI : MonoBehaviour
+{
+    public Image icon;
+    public Text nameText;
+    public Text descriptionText;
+
+    public void Setup(PerkData data)
+    {
+        if (data == null)
+            return;
+        if (icon != null) icon.sprite = data.icon;
+        if (nameText != null) nameText.text = data.perkName;
+        if (descriptionText != null) descriptionText.text = data.description;
+    }
+}

--- a/Assets/Scripts/UI/PerkPreviewPanel.cs
+++ b/Assets/Scripts/UI/PerkPreviewPanel.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Read-only list showing the hero's passive perks.
+/// </summary>
+public class PerkPreviewPanel : MonoBehaviour
+{
+    public PerkEntryUI entryPrefab;
+    public Transform container;
+
+    private readonly List<GameObject> created = new();
+
+    /// <summary>
+    /// Populates the panel with the given perks.
+    /// </summary>
+    public void Populate(List<PerkData> perks)
+    {
+        Clear();
+        if (perks == null) return;
+        foreach (var perk in perks)
+        {
+            var entry = Instantiate(entryPrefab, container);
+            entry.Setup(perk);
+            created.Add(entry.gameObject);
+        }
+    }
+
+    private void Clear()
+    {
+        foreach (var go in created)
+            Destroy(go);
+        created.Clear();
+    }
+}

--- a/Assets/Scripts/UI/PreparationPanel.cs
+++ b/Assets/Scripts/UI/PreparationPanel.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Main controller that coordinates the battle preparation UI.
+/// </summary>
+public class PreparationPanel : MonoBehaviour
+{
+    [Header("Sub Panels")]
+    public SelectSquadPanel selectSquadPanel;
+    public HeroViewerPanel heroViewerPanel;
+    public PerkPreviewPanel perkPreviewPanel;
+
+    [Header("Tab Buttons")]
+    public Button squadsTabButton;
+    public Button heroTabButton;
+    public Button perksTabButton;
+
+    [Header("Other UI")]
+    public Button confirmButton;
+    public GameObject panelRoot;
+
+    private SquadLoadout selectedLoadout;
+
+    public event System.Action OnPreparationComplete;
+
+    private void Awake()
+    {
+        if (confirmButton != null)
+            confirmButton.onClick.AddListener(OnConfirm);
+        if (squadsTabButton != null)
+            squadsTabButton.onClick.AddListener(() => ShowPanel(selectSquadPanel.gameObject));
+        if (heroTabButton != null)
+            heroTabButton.onClick.AddListener(() => ShowPanel(heroViewerPanel.gameObject));
+        if (perksTabButton != null)
+            perksTabButton.onClick.AddListener(() => ShowPanel(perkPreviewPanel.gameObject));
+    }
+
+    private void Start()
+    {
+        LoadData();
+        ShowPanel(selectSquadPanel.gameObject);
+    }
+
+    private void LoadData()
+    {
+        var squads = PlayerProfileManager.GetUnlockedSquads();
+        selectSquadPanel.Populate(squads);
+        selectSquadPanel.OnLoadoutSelected += l => selectedLoadout = l;
+
+        var hero = PlayerProfileManager.GetActiveCharacter();
+        heroViewerPanel.LoadHero(hero);
+        if (hero != null)
+            perkPreviewPanel.Populate(hero.passivePerks);
+    }
+
+    private void ShowPanel(GameObject target)
+    {
+        selectSquadPanel.gameObject.SetActive(target == selectSquadPanel.gameObject);
+        heroViewerPanel.gameObject.SetActive(target == heroViewerPanel.gameObject);
+        perkPreviewPanel.gameObject.SetActive(target == perkPreviewPanel.gameObject);
+    }
+
+    private void OnConfirm()
+    {
+        if (selectedLoadout == null)
+        {
+            Debug.LogWarning("No squad loadout selected");
+            return;
+        }
+        GameManager.SpawnSquad(selectedLoadout);
+        if (panelRoot != null)
+            panelRoot.SetActive(false);
+        OnPreparationComplete?.Invoke();
+    }
+}

--- a/Assets/Scripts/UI/SelectSquadPanel.cs
+++ b/Assets/Scripts/UI/SelectSquadPanel.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Displays available squad loadouts for the player to choose from.
+/// </summary>
+public class SelectSquadPanel : MonoBehaviour
+{
+    public Button entryPrefab;
+    public Transform listContainer;
+
+    private readonly List<Button> created = new();
+    private List<SquadLoadout> loadouts;
+
+    public System.Action<SquadLoadout> OnLoadoutSelected;
+    public SquadLoadout SelectedLoadout { get; private set; }
+
+    /// <summary>
+    /// Populates the UI with all available loadouts.
+    /// </summary>
+    public void Populate(List<SquadLoadout> available)
+    {
+        Clear();
+        loadouts = available;
+        foreach (var loadout in loadouts)
+        {
+            Button btn = Instantiate(entryPrefab, listContainer);
+            created.Add(btn);
+            btn.GetComponentInChildren<Text>().text = loadout.name;
+
+            btn.interactable = IsLoadoutViable(loadout);
+            var l = loadout;
+            btn.onClick.AddListener(() => Select(l));
+        }
+    }
+
+    private bool IsLoadoutViable(SquadLoadout loadout)
+    {
+        if (loadout == null)
+            return false;
+        foreach (var troop in loadout.troops)
+        {
+            if (SquadStatsTracker.Instance.GetRemainingTroopPercentage(troop) <= 0.1f)
+                return false;
+        }
+        return true;
+    }
+
+    private void Select(SquadLoadout loadout)
+    {
+        SelectedLoadout = loadout;
+        OnLoadoutSelected?.Invoke(loadout);
+    }
+
+    private void Clear()
+    {
+        foreach (var b in created)
+            Destroy(b.gameObject);
+        created.Clear();
+        SelectedLoadout = null;
+    }
+}


### PR DESCRIPTION
## Summary
- add stub player profile and game manager infrastructure
- implement PreparationPanel controller with tabs
- implement SelectSquadPanel, HeroViewerPanel and PerkPreviewPanel
- add supporting data classes and compile entries

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ce1f6ea48332a2b0bcd40eecc064