### PR TITLE
Add in-battle squad swap UI

### DIFF
--- a/Assets/Scripts/Squads/SupplyPointController.cs
+++ b/Assets/Scripts/Squads/SupplyPointController.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections;
+using System.Collections.Generic;
 
 /// <summary>
 /// Example supply point that allows replacing the active squad.
@@ -15,6 +16,12 @@ public class SupplyPointController : MonoBehaviour
     [Tooltip("Cooldown time between interactions")]
     public float cooldown = 5f;
 
+    // Tracks whether the point has been consumed.
+    private bool used;
+    // Tracks loadouts already chosen in this battle.
+    private readonly HashSet<SquadLoadout> usedLoadouts = new();
+    public IReadOnlyCollection<SquadLoadout> UsedLoadouts => usedLoadouts;
+
     private bool onCooldown;
     private bool playerInside;
 
@@ -27,7 +34,11 @@ public class SupplyPointController : MonoBehaviour
     private void OnTriggerExit(Collider other)
     {
         if (other.CompareTag("Player"))
+        {
             playerInside = false;
+            if (interactionUI != null)
+                interactionUI.Hide();
+        }
     }
 
     /// <summary>
@@ -35,7 +46,7 @@ public class SupplyPointController : MonoBehaviour
     /// </summary>
     public void Interact()
     {
-        if (onCooldown || !playerInside)
+        if (onCooldown || !playerInside || used)
             return;
 
         if (interactionUI != null)
@@ -63,6 +74,13 @@ public class SupplyPointController : MonoBehaviour
 
         yield return new WaitForSeconds(cooldown);
         onCooldown = false;
+    }
+
+    public void MarkUsed(SquadLoadout loadout)
+    {
+        if (loadout != null)
+            usedLoadouts.Add(loadout);
+        used = true;
     }
 }
 

--- a/Assets/Scripts/Squads/SupplyPointInteractionUI.cs
+++ b/Assets/Scripts/Squads/SupplyPointInteractionUI.cs
@@ -1,13 +1,99 @@
 using UnityEngine;
+using UnityEngine.UI;
+using System.Collections;
+using System.Collections.Generic;
 
 /// <summary>
-/// Minimal placeholder UI controller for interacting with supply points.
+/// UI panel shown when the player interacts with a supply point.
+/// Allows selecting a new squad during battle.
 /// </summary>
 public class SupplyPointInteractionUI : MonoBehaviour
 {
+    [Header("References")]
+    public SelectSquadPanel selectSquadPanel;
+    public Button cancelButton;
+    public CanvasGroup canvasGroup;
+    public float fadeDuration = 0.2f;
+
+    private SupplyPointController currentPoint;
+
+    private void Awake()
+    {
+        if (cancelButton != null)
+            cancelButton.onClick.AddListener(Hide);
+    }
+
+    /// <summary>
+    /// Opens the panel and populates squad options provided by the player profile.
+    /// </summary>
     public void ShowOptions(SupplyPointController point)
     {
-        // Display UI - implementation can be extended.
+        currentPoint = point;
+
+        if (selectSquadPanel != null)
+        {
+            var squads = PlayerProfileManager.GetUnlockedSquads();
+            var disabled = new HashSet<SquadLoadout>(point.UsedLoadouts);
+            selectSquadPanel.OnSquadSelected = OnSquadSelected;
+            selectSquadPanel.Populate(squads, disabled);
+        }
+
         gameObject.SetActive(true);
+        StartCoroutine(FadeRoutine(1f));
+    }
+
+    public void Hide()
+    {
+        if (gameObject.activeSelf)
+            StartCoroutine(FadeRoutine(0f));
+    }
+
+    private IEnumerator FadeRoutine(float target)
+    {
+        if (canvasGroup == null)
+        {
+            canvasGroup = GetComponent<CanvasGroup>();
+            if (canvasGroup == null)
+            {
+                gameObject.SetActive(target > 0f);
+                yield break;
+            }
+        }
+
+        float start = canvasGroup.alpha;
+        float time = 0f;
+        if (target > 0f)
+            gameObject.SetActive(true);
+        while (time < fadeDuration)
+        {
+            time += Time.unscaledDeltaTime;
+            canvasGroup.alpha = Mathf.Lerp(start, target, time / fadeDuration);
+            yield return null;
+        }
+        canvasGroup.alpha = target;
+        if (target == 0f)
+            gameObject.SetActive(false);
+    }
+
+    private void OnSquadSelected(SquadLoadout loadout)
+    {
+        if (loadout != null)
+            StartCoroutine(PerformChange(loadout));
+    }
+
+    private IEnumerator PerformChange(SquadLoadout loadout)
+    {
+        var manager = SquadManager.Instance;
+        if (manager != null)
+        {
+            manager.DeactivateCurrentSquad(currentPoint != null ? currentPoint.despawnDelay : 0f);
+            yield return new WaitForSeconds(currentPoint != null ? currentPoint.despawnDelay : 0f);
+            manager.SpawnSquadFromLoadoutAt(loadout, manager.defaultSpawnPoint.position);
+        }
+
+        if (currentPoint != null)
+            currentPoint.MarkUsed(loadout);
+
+        Hide();
     }
 }

--- a/Assets/Scripts/UI/PreparationPanel.cs
+++ b/Assets/Scripts/UI/PreparationPanel.cs
@@ -47,7 +47,7 @@ public class PreparationPanel : MonoBehaviour
     {
         var squads = PlayerProfileManager.GetUnlockedSquads();
         selectSquadPanel.Populate(squads);
-        selectSquadPanel.OnLoadoutSelected += l => selectedLoadout = l;
+        selectSquadPanel.OnSquadSelected += l => selectedLoadout = l;
 
         var hero = PlayerProfileManager.GetActiveCharacter();
         heroViewerPanel.LoadHero(hero);


### PR DESCRIPTION
## Summary
- make `SelectSquadPanel` reusable with callback and warning for low troops
- hook up new event usage in `PreparationPanel`
- track used loadouts and usage state in `SupplyPointController`
- implement `SupplyPointInteractionUI` to change squads at supply points

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d11e20608332bedd661f3f679be1