### PR TITLE
Implement BattleManager core logic

### DIFF
--- a/Assets/Scripts/Game/BattleManager.cs
+++ b/Assets/Scripts/Game/BattleManager.cs
@@ -1,0 +1,176 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// Coordinates the battle flow, checking for victory or defeat conditions
+/// and broadcasting the final result.
+/// </summary>
+public class BattleManager : MonoBehaviour
+{
+    /// <summary>
+    /// Global access to the active BattleManager instance.
+    /// </summary>
+    public static BattleManager Instance { get; private set; }
+
+    /// <summary>
+    /// Possible states of the battle lifecycle.
+    /// </summary>
+    public enum BattleState { NotStarted, Ongoing, Victory, Defeat }
+
+    /// <summary>
+    /// Current battle state, read only for other systems.
+    /// </summary>
+    public BattleState CurrentState { get; private set; } = BattleState.NotStarted;
+
+    /// <summary>
+    /// Event invoked when the battle finishes.
+    /// </summary>
+    public event System.Action<BattleState> OnBattleEnd;
+
+    private bool hasBattleEnded;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    private void Start()
+    {
+        StartBattle();
+    }
+
+    /// <summary>
+    /// Prepares the scene and switches the manager to the Ongoing state.
+    /// </summary>
+    private void StartBattle()
+    {
+        ChangeState(BattleState.Ongoing);
+        StartCoroutine(MonitorBattleConditions());
+    }
+
+    /// <summary>
+    /// Periodically verifies victory or defeat conditions.
+    /// </summary>
+    private IEnumerator MonitorBattleConditions()
+    {
+        while (!hasBattleEnded)
+        {
+            yield return new WaitForSeconds(1f);
+
+            if (CurrentState != BattleState.Ongoing)
+                continue;
+
+            if (SquadManager.Instance != null && SquadManager.Instance.HasNoUnits())
+            {
+                EndBattle(BattleState.Defeat);
+                yield break;
+            }
+
+            if (EnemyManager.Instance != null && EnemyManager.Instance.AreAllDead())
+            {
+                EndBattle(BattleState.Victory);
+                yield break;
+            }
+
+#if UNITY_EDITOR
+            if (Input.GetKeyDown(KeyCode.F10))
+            {
+                EndBattle(BattleState.Victory);
+                yield break;
+            }
+            if (Input.GetKeyDown(KeyCode.F11))
+            {
+                EndBattle(BattleState.Defeat);
+                yield break;
+            }
+#endif
+        }
+    }
+
+    /// <summary>
+    /// Finalizes the battle and notifies subscribers.
+    /// </summary>
+    private void EndBattle(BattleState result)
+    {
+        if (hasBattleEnded)
+            return;
+
+        hasBattleEnded = true;
+        ChangeState(result);
+        Debug.Log($"Battle ended with result: {result}");
+
+        BattleResultData data = BuildResultData(result);
+
+        OnBattleEnd?.Invoke(result);
+        EndBattleHandler.HandleBattleEnd(result);
+
+        // Optionally forward results to any UI component listening.
+        var ui = FindObjectOfType<BattleResultsUI>();
+        if (ui != null)
+            ui.Show(data);
+    }
+
+    /// <summary>
+    /// Gathers final information used for the results screen.
+    /// </summary>
+    private BattleResultData BuildResultData(BattleState result)
+    {
+        float time = BattleTimer.GetElapsedTime();
+        string name = GetSquadName();
+
+        int initial = GetInitialTroopCount();
+        int survivors = GetSurvivingTroopCount();
+
+        return new BattleResultData
+        {
+            result = result,
+            totalTime = time,
+            squadName = name,
+            initialTroops = initial,
+            survivingTroops = survivors
+        };
+    }
+
+    /// <summary>
+    /// Delegate for other systems to obtain the current squad name.
+    /// </summary>
+    public string GetSquadName()
+    {
+        return SquadManager.Instance != null && SquadManager.Instance.activeSquad != null && SquadManager.Instance.activeSquad.Loadout != null
+            ? SquadManager.Instance.activeSquad.Loadout.name
+            : string.Empty;
+    }
+
+    private int GetInitialTroopCount()
+    {
+        if (SquadManager.Instance == null || SquadManager.Instance.activeSquad == null || SquadManager.Instance.activeSquad.Loadout == null)
+            return 0;
+
+        int count = 0;
+        foreach (var t in SquadManager.Instance.activeSquad.Loadout.troops)
+        {
+            if (t != null)
+                count += t.unitCount;
+        }
+        return count;
+    }
+
+    private int GetSurvivingTroopCount()
+    {
+        return SquadManager.Instance != null ? SquadManager.Instance.GetActiveUnits().Count : 0;
+    }
+
+    private void ChangeState(BattleState newState)
+    {
+        if (CurrentState == newState)
+            return;
+
+        CurrentState = newState;
+        Debug.Log($"BattleManager state changed to {newState}");
+    }
+}

--- a/Assets/Scripts/Game/BattleResultData.cs
+++ b/Assets/Scripts/Game/BattleResultData.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+/// <summary>
+/// Data container with final statistics of a battle.
+/// </summary>
+public class BattleResultData
+{
+    public BattleManager.BattleState result;
+    public float totalTime;
+    public string squadName;
+    public int initialTroops;
+    public int survivingTroops;
+}

--- a/Assets/Scripts/Game/BattleTimer.cs
+++ b/Assets/Scripts/Game/BattleTimer.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple utility to track how much time has passed since the battle started.
+/// </summary>
+public static class BattleTimer
+{
+    private static float startTime;
+    private static bool started;
+
+    /// <summary>
+    /// Starts or resets the timer.
+    /// </summary>
+    public static void StartTimer()
+    {
+        startTime = Time.time;
+        started = true;
+    }
+
+    /// <summary>
+    /// Returns the elapsed time in seconds since the timer started.
+    /// </summary>
+    public static float GetElapsedTime()
+    {
+        return started ? Time.time - startTime : 0f;
+    }
+}

--- a/Assets/Scripts/Game/EndBattleHandler.cs
+++ b/Assets/Scripts/Game/EndBattleHandler.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+/// <summary>
+/// Handles final actions once the battle is over.
+/// This is a placeholder implementation that can be expanded later.
+/// </summary>
+public static class EndBattleHandler
+{
+    public static void HandleBattleEnd(BattleManager.BattleState result)
+    {
+        Debug.Log($"EndBattleHandler received result: {result}");
+        // Additional behaviour such as scene transitions would go here.
+    }
+}

--- a/Assets/Scripts/Game/EnemyManager.cs
+++ b/Assets/Scripts/Game/EnemyManager.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Tracks all enemy units present in the scene.
+/// </summary>
+public class EnemyManager : MonoBehaviour
+{
+    public static EnemyManager Instance { get; private set; }
+
+    private readonly List<HealthComponent> enemies = new();
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    /// <summary>
+    /// Registers a new enemy so it can be tracked.
+    /// </summary>
+    public void RegisterEnemy(HealthComponent enemy)
+    {
+        if (enemy == null || enemies.Contains(enemy))
+            return;
+
+        enemies.Add(enemy);
+        enemy.OnDeath += () => enemies.Remove(enemy);
+    }
+
+    /// <summary>
+    /// Returns true when all registered enemies are dead or missing.
+    /// </summary>
+    public bool AreAllDead()
+    {
+        enemies.RemoveAll(e => e == null);
+
+        if (enemies.Count == 0)
+            return false;
+
+        foreach (var e in enemies)
+        {
+            if (e.IsAlive)
+                return false;
+        }
+        return true;
+    }
+}

--- a/Assets/Scripts/Squads/SquadManager.cs
+++ b/Assets/Scripts/Squads/SquadManager.cs
@@ -74,5 +74,38 @@ public class SquadManager : MonoBehaviour
     {
         return activeSquad != null ? activeSquad.GetUnits() : new List<UnitController>();
     }
+
+    /// <summary>
+    /// Returns true when there are no units alive in the current squad.
+    /// </summary>
+    public bool HasNoUnits()
+    {
+        return GetActiveUnits().Count == 0;
+    }
+
+    /// <summary>
+    /// Total number of units defined in the active loadout.
+    /// </summary>
+    public int GetInitialUnitCount()
+    {
+        if (activeSquad == null || activeSquad.Loadout == null)
+            return 0;
+
+        int count = 0;
+        foreach (var troop in activeSquad.Loadout.troops)
+        {
+            if (troop != null)
+                count += troop.unitCount;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Current count of alive units in the active squad.
+    /// </summary>
+    public int GetCurrentUnitCount()
+    {
+        return GetActiveUnits().Count;
+    }
 }
 

--- a/Assets/Scripts/UI/BattleResultsUI.cs
+++ b/Assets/Scripts/UI/BattleResultsUI.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple placeholder for displaying battle results.
+/// </summary>
+public class BattleResultsUI : MonoBehaviour
+{
+    public void Show(BattleResultData data)
+    {
+        Debug.Log($"Showing results: {data.result} - Time {data.totalTime}");
+    }
+}


### PR DESCRIPTION
## Summary
- add `BattleManager` core system with battle state control
- add `BattleResultData` container
- implement basic `BattleTimer`, `EndBattleHandler`, and `EnemyManager`
- expand `SquadManager` with unit count helpers
- stub `BattleResultsUI`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d372d57483328ec4097f9079780f