### PR TITLE
Add battle results UI

### DIFF
--- a/Assets/Scripts/Game/BattleManager.cs
+++ b/Assets/Scripts/Game/BattleManager.cs
@@ -112,7 +112,7 @@ public class BattleManager : MonoBehaviour
         // Optionally forward results to any UI component listening.
         var ui = FindObjectOfType<BattleResultsUI>();
         if (ui != null)
-            ui.Show(data);
+            ui.ShowResults(data);
     }
 
     /// <summary>
@@ -129,10 +129,11 @@ public class BattleManager : MonoBehaviour
         return new BattleResultData
         {
             result = result,
-            totalTime = time,
             squadName = name,
-            initialTroops = initial,
-            survivingTroops = survivors
+            unitsInitial = initial,
+            unitsRemaining = survivors,
+            battleDuration = time,
+            enemiesDefeated = 0
         };
     }
 

--- a/Assets/Scripts/Game/BattleResultData.cs
+++ b/Assets/Scripts/Game/BattleResultData.cs
@@ -5,9 +5,33 @@ using UnityEngine;
 /// </summary>
 public class BattleResultData
 {
+    /// <summary>
+    /// Final state of the battle.
+    /// </summary>
     public BattleManager.BattleState result;
-    public float totalTime;
+
+    /// <summary>
+    /// Name of the squad used by the player.
+    /// </summary>
     public string squadName;
-    public int initialTroops;
-    public int survivingTroops;
+
+    /// <summary>
+    /// Units remaining at the end of the battle.
+    /// </summary>
+    public int unitsRemaining;
+
+    /// <summary>
+    /// Units the player started the battle with.
+    /// </summary>
+    public int unitsInitial;
+
+    /// <summary>
+    /// Total duration of the battle in seconds.
+    /// </summary>
+    public float battleDuration;
+
+    /// <summary>
+    /// Optional number of defeated enemies.
+    /// </summary>
+    public int enemiesDefeated;
 }

--- a/Assets/Scripts/Game/SceneLoader.cs
+++ b/Assets/Scripts/Game/SceneLoader.cs
@@ -1,0 +1,23 @@
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Utility class for handling scene transitions.
+/// </summary>
+public static class SceneLoader
+{
+    private static string nextScene;
+
+    /// <summary>
+    /// Loads a given scene through an optional loading screen.
+    /// </summary>
+    public static void LoadScene(string sceneName)
+    {
+        nextScene = sceneName;
+        SceneManager.LoadScene("LoadingScreen");
+    }
+
+    /// <summary>
+    /// Returns the scene name queued for loading.
+    /// </summary>
+    public static string GetNextScene() => nextScene;
+}

--- a/Assets/Scripts/UI/BattleResultsUI.cs
+++ b/Assets/Scripts/UI/BattleResultsUI.cs
@@ -1,12 +1,142 @@
+using System.Collections;
+using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 /// <summary>
-/// Simple placeholder for displaying battle results.
+/// Displays the final battle summary once the fight ends.
 /// </summary>
 public class BattleResultsUI : MonoBehaviour
 {
-    public void Show(BattleResultData data)
+    [Header("UI References")]
+    public CanvasGroup panelGroup;
+    public TextMeshProUGUI titleText;
+    public TextMeshProUGUI squadNameText;
+    public TextMeshProUGUI troopCountText;
+    public TextMeshProUGUI timeText;
+    public TextMeshProUGUI enemiesText;
+    public Button continueButton;
+
+    [Header("Settings")]
+    public string lobbyScene = "Lobby";
+    public float delayBeforeShowing = 2f;
+    public bool animate = true;
+
+    private void Awake()
     {
-        Debug.Log($"Showing results: {data.result} - Time {data.totalTime}");
+        if (continueButton != null)
+            continueButton.onClick.AddListener(OnContinue);
+
+        if (panelGroup != null)
+        {
+            panelGroup.alpha = 0f;
+            panelGroup.interactable = false;
+            panelGroup.blocksRaycasts = false;
+            panelGroup.gameObject.SetActive(false);
+        }
+    }
+
+    /// <summary>
+    /// Populates the UI and makes it visible.
+    /// </summary>
+    public void ShowResults(BattleResultData data)
+    {
+        StartCoroutine(ShowRoutine(data));
+    }
+
+    private IEnumerator ShowRoutine(BattleResultData data)
+    {
+        if (delayBeforeShowing > 0f)
+            yield return new WaitForSeconds(delayBeforeShowing);
+
+        UpdateTexts(data);
+
+        if (panelGroup != null)
+        {
+            panelGroup.gameObject.SetActive(true);
+            if (animate)
+                yield return StartCoroutine(FadeIn());
+            else
+            {
+                panelGroup.alpha = 1f;
+                panelGroup.interactable = true;
+                panelGroup.blocksRaycasts = true;
+            }
+        }
+    }
+
+    private void UpdateTexts(BattleResultData data)
+    {
+        bool victory = data.result == BattleManager.BattleState.Victory;
+        if (titleText != null)
+        {
+            titleText.text = victory ? "¡Victoria!" : "Derrota";
+            titleText.color = victory ? Color.green : Color.red;
+        }
+
+        if (squadNameText != null)
+            squadNameText.text = data.squadName;
+
+        if (troopCountText != null)
+            troopCountText.text = $"{data.unitsRemaining}/{data.unitsInitial}";
+
+        if (timeText != null)
+            timeText.text = FormatTime(data.battleDuration);
+
+        if (enemiesText != null)
+        {
+            if (data.enemiesDefeated > 0)
+            {
+                enemiesText.gameObject.SetActive(true);
+                enemiesText.text = data.enemiesDefeated.ToString();
+            }
+            else
+            {
+                enemiesText.gameObject.SetActive(false);
+            }
+        }
+    }
+
+    private IEnumerator FadeIn()
+    {
+        float t = 0f;
+        while (t < 1f)
+        {
+            t += Time.deltaTime;
+            if (panelGroup != null)
+                panelGroup.alpha = Mathf.Lerp(0f, 1f, t);
+            yield return null;
+        }
+        if (panelGroup != null)
+        {
+            panelGroup.alpha = 1f;
+            panelGroup.interactable = true;
+            panelGroup.blocksRaycasts = true;
+        }
+    }
+
+    private static string FormatTime(float seconds)
+    {
+        int mins = Mathf.FloorToInt(seconds / 60f);
+        int secs = Mathf.FloorToInt(seconds % 60f);
+        return $"{mins:00}:{secs:00}";
+    }
+
+    private void OnContinue()
+    {
+        DisablePlayerInput();
+        SceneLoader.LoadScene(lobbyScene);
+        if (panelGroup != null)
+            panelGroup.gameObject.SetActive(false);
+    }
+
+    private void DisablePlayerInput()
+    {
+        var input = FindObjectOfType<HeroInputController>();
+        if (input != null)
+            input.enabled = false;
+        var movement = FindObjectOfType<PlayerMovement>();
+        if (movement != null)
+            movement.enabled = false;
     }
 }


### PR DESCRIPTION
## Summary
- expand `BattleResultData` with detailed stats
- implement `SceneLoader` utility for scene transitions
- create rich `BattleResultsUI` script
- update `BattleManager` integration with the new UI

## Testing
- `dotnet build ConquestTactics_prototype.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856db71b1548332bc6d7e0cfa6abcac