### PR TITLE
Add asynchronous scene loader

### DIFF
--- a/Assets/Scripts/Game/SceneLoader.cs
+++ b/Assets/Scripts/Game/SceneLoader.cs
@@ -1,23 +1,92 @@
+using System.Collections;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 
 /// <summary>
-/// Utility class for handling scene transitions.
+/// Static helper responsible for changing scenes asynchronously.
 /// </summary>
 public static class SceneLoader
 {
-    private static string nextScene;
+    /// <summary>
+    /// Indicates if a scene is currently being loaded.
+    /// </summary>
+    public static bool isLoading { get; private set; }
+
+    // Internal runner to start coroutines without requiring a scene object.
+    private class LoaderRunner : MonoBehaviour { }
+    private static LoaderRunner runner;
 
     /// <summary>
-    /// Loads a given scene through an optional loading screen.
+    /// Ensures there is a runner object in the scene to host coroutines.
     /// </summary>
-    public static void LoadScene(string sceneName)
+    private static void EnsureRunner()
     {
-        nextScene = sceneName;
-        SceneManager.LoadScene("LoadingScreen");
+        if (runner != null)
+            return;
+        var obj = new GameObject("SceneLoaderRunner");
+        Object.DontDestroyOnLoad(obj);
+        runner = obj.AddComponent<LoaderRunner>();
     }
 
     /// <summary>
-    /// Returns the scene name queued for loading.
+    /// Starts asynchronous loading of the target scene.
+    /// Shows the LoadingScreen if present.
     /// </summary>
-    public static string GetNextScene() => nextScene;
+    /// <param name="sceneName">Name of the scene to load.</param>
+    public static void LoadScene(string sceneName)
+    {
+        if (isLoading)
+        {
+            Debug.LogWarning("SceneLoader: attempted to load a scene while another load is in progress.");
+            return;
+        }
+        if (SceneManager.GetActiveScene().name == sceneName)
+        {
+            Debug.LogWarning($"SceneLoader: scene '{sceneName}' is already active.");
+            return;
+        }
+
+        EnsureRunner();
+        runner.StartCoroutine(LoadRoutine(sceneName));
+    }
+
+    /// <summary>
+    /// Coroutine that performs the actual asynchronous scene loading.
+    /// </summary>
+    private static IEnumerator LoadRoutine(string sceneName)
+    {
+        isLoading = true;
+
+        if (LoadingScreen.Instance != null)
+            LoadingScreen.Instance.Show();
+
+        Debug.Log($"Cargando escena {sceneName}...");
+
+        AsyncOperation op = SceneManager.LoadSceneAsync(sceneName);
+        while (!op.isDone)
+        {
+            // Future: report progress to LoadingScreen here
+            yield return null;
+        }
+
+        if (LoadingScreen.Instance != null)
+            LoadingScreen.Instance.Hide();
+
+        isLoading = false;
+    }
+
+    /// <summary>
+    /// Loads the lobby scene.
+    /// </summary>
+    public static void LoadLobby() => LoadScene("Lobby");
+
+    /// <summary>
+    /// Loads the main menu scene.
+    /// </summary>
+    public static void LoadMainMenu() => LoadScene("MainMenu");
+
+    /// <summary>
+    /// Loads a battle scene by name.
+    /// </summary>
+    public static void LoadBattle(string mapName) => LoadScene(mapName);
 }

--- a/Assets/Scripts/UI/LoadingScreen.cs
+++ b/Assets/Scripts/UI/LoadingScreen.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple loading screen controller shown during scene transitions.
+/// The object can exist as a prefab in the initial scene.
+/// </summary>
+public class LoadingScreen : MonoBehaviour
+{
+    /// <summary>
+    /// Global access to the active LoadingScreen, if any.
+    /// </summary>
+    public static LoadingScreen Instance { get; private set; }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Displays the loading screen.
+    /// </summary>
+    public void Show()
+    {
+        gameObject.SetActive(true);
+    }
+
+    /// <summary>
+    /// Hides the loading screen.
+    /// </summary>
+    public void Hide()
+    {
+        gameObject.SetActive(false);
+    }
+}


### PR DESCRIPTION
## Summary
- implement new static `SceneLoader` to load scenes asynchronously and manage optional loading screen
- add `LoadingScreen` component as a simple singleton prefab controller

## Testing
- `dotnet build ConquestTactics_prototype.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e2f9680c83328a8bd2d7797ab160