### PR TITLE
Implement battle timer component

### DIFF
--- a/Assets/Scripts/Game/BattleManager.cs
+++ b/Assets/Scripts/Game/BattleManager.cs
@@ -50,6 +50,8 @@ public class BattleManager : MonoBehaviour
     private void StartBattle()
     {
         ChangeState(BattleState.Ongoing);
+        if (BattleTimer.Instance != null)
+            BattleTimer.Instance.StartTimer();
         StartCoroutine(MonitorBattleConditions());
     }
 
@@ -101,6 +103,8 @@ public class BattleManager : MonoBehaviour
             return;
 
         hasBattleEnded = true;
+        if (BattleTimer.Instance != null)
+            BattleTimer.Instance.StopTimer();
         ChangeState(result);
         Debug.Log($"Battle ended with result: {result}");
 
@@ -159,6 +163,15 @@ public class BattleManager : MonoBehaviour
                 count += t.unitCount;
         }
         return count;
+    }
+
+    /// <summary>
+    /// Forces the battle to end in defeat.
+    /// </summary>
+    public void ForceDefeat(string reason)
+    {
+        Debug.Log($"BattleManager forced defeat: {reason}");
+        EndBattle(BattleState.Defeat);
     }
 
     private int GetSurvivingTroopCount()

--- a/Assets/Scripts/Game/BattleTimer.cs
+++ b/Assets/Scripts/Game/BattleTimer.cs
@@ -1,27 +1,123 @@
 using UnityEngine;
 
 /// <summary>
-/// Simple utility to track how much time has passed since the battle started.
+/// Component that tracks battle duration and notifies interested systems.
 /// </summary>
-public static class BattleTimer
+public class BattleTimer : MonoBehaviour
 {
-    private static float startTime;
-    private static bool started;
+    /// <summary>
+    /// Global access to the active timer instance.
+    /// </summary>
+    public static BattleTimer Instance { get; private set; }
+
+    [Header("Time Limit")]
+    public bool useTimeLimit = false;
+    public float timeLimit = 300f;
 
     /// <summary>
-    /// Starts or resets the timer.
+    /// Invoked every frame while the timer is running with the current time.
     /// </summary>
-    public static void StartTimer()
+    public event System.Action<float> OnTimerTick;
+
+    /// <summary>
+    /// Invoked once when remaining time drops below 30 seconds.
+    /// </summary>
+    public event System.Action<float> OnTimeWarning;
+
+    private float elapsedTime;
+    private bool running;
+    private bool warningSent;
+
+    private void Awake()
     {
-        startTime = Time.time;
-        started = true;
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    private void Update()
+    {
+        if (!running)
+            return;
+
+        elapsedTime += Time.deltaTime;
+        OnTimerTick?.Invoke(elapsedTime);
+
+        if (useTimeLimit)
+        {
+            float remaining = timeLimit - elapsedTime;
+            if (!warningSent && remaining <= 30f)
+            {
+                warningSent = true;
+                OnTimeWarning?.Invoke(remaining);
+            }
+
+            if (elapsedTime >= timeLimit)
+            {
+                running = false;
+                Debug.Log("BattleTimer reached time limit");
+                if (BattleManager.Instance != null)
+                    BattleManager.Instance.ForceDefeat("Tiempo agotado");
+            }
+        }
     }
 
     /// <summary>
-    /// Returns the elapsed time in seconds since the timer started.
+    /// Starts counting time from zero.
+    /// </summary>
+    public void StartTimer()
+    {
+        elapsedTime = 0f;
+        running = true;
+        warningSent = false;
+    }
+
+    /// <summary>
+    /// Stops the timer.
+    /// </summary>
+    public void StopTimer()
+    {
+        running = false;
+    }
+
+    /// <summary>
+    /// Returns the current elapsed time in seconds.
     /// </summary>
     public static float GetElapsedTime()
     {
-        return started ? Time.time - startTime : 0f;
+        return Instance != null ? Instance.elapsedTime : 0f;
+    }
+
+    /// <summary>
+    /// Returns the elapsed time formatted as mm:ss.
+    /// </summary>
+    public string GetFormattedTime()
+    {
+        int mins = Mathf.FloorToInt(elapsedTime / 60f);
+        int secs = Mathf.FloorToInt(elapsedTime % 60f);
+        return $"{mins:00}:{secs:00}";
+    }
+
+    /// <summary>
+    /// Returns the formatted elapsed time from the active instance.
+    /// </summary>
+    public static string GetFormattedElapsedTime()
+    {
+        return Instance != null ? Instance.GetFormattedTime() : "00:00";
+    }
+
+    [ContextMenu("Start Timer")]
+    private void ContextStart()
+    {
+        StartTimer();
+    }
+
+    [ContextMenu("Stop Timer")]
+    private void ContextStop()
+    {
+        StopTimer();
     }
 }

--- a/Assets/Scripts/UI/InBattleHUD.cs
+++ b/Assets/Scripts/UI/InBattleHUD.cs
@@ -13,6 +13,7 @@ public class InBattleHUD : MonoBehaviour
     public TextMeshProUGUI squadNameText;
     public TextMeshProUGUI troopCountText;
     public TextMeshProUGUI formationText;
+    public TextMeshProUGUI timerText;
     public Button followButton;
     public Button holdButton;
     public Button attackButton;
@@ -21,6 +22,7 @@ public class InBattleHUD : MonoBehaviour
     [Header("Visual Feedback")]
     public Color activeColor = Color.green;
     public Color inactiveColor = Color.white;
+    public Color timeWarningColor = Color.red;
 
     public event System.Action OnChangeFormationRequest;
 
@@ -45,6 +47,13 @@ public class InBattleHUD : MonoBehaviour
     private void OnEnable()
     {
         BattleManager.Instance.OnBattleEnd += HandleBattleEnd;
+        if (BattleTimer.Instance != null)
+        {
+            BattleTimer.Instance.OnTimerTick += UpdateTimerText;
+            BattleTimer.Instance.OnTimeWarning += DisplayTimeWarning;
+            if (timerText != null)
+                timerText.text = BattleTimer.GetFormattedElapsedTime();
+        }
         updateTimer = 1f;
         UpdateHUD();
     }
@@ -53,6 +62,11 @@ public class InBattleHUD : MonoBehaviour
     {
         if (BattleManager.Instance != null)
             BattleManager.Instance.OnBattleEnd -= HandleBattleEnd;
+        if (BattleTimer.Instance != null)
+        {
+            BattleTimer.Instance.OnTimerTick -= UpdateTimerText;
+            BattleTimer.Instance.OnTimeWarning -= DisplayTimeWarning;
+        }
     }
 
     private void Update()
@@ -166,6 +180,18 @@ public class InBattleHUD : MonoBehaviour
     private void RequestFormationChange()
     {
         OnChangeFormationRequest?.Invoke();
+    }
+
+    private void UpdateTimerText(float time)
+    {
+        if (timerText != null)
+            timerText.text = BattleTimer.GetFormattedElapsedTime();
+    }
+
+    private void DisplayTimeWarning(float remaining)
+    {
+        if (timerText != null)
+            timerText.color = timeWarningColor;
     }
 
     private void HandleBattleEnd(BattleManager.BattleState state)


### PR DESCRIPTION
## Summary
- replace static `BattleTimer` with a MonoBehaviour that tracks elapsed time
- start/stop timer from `BattleManager` and expose `ForceDefeat`
- show timer in `InBattleHUD` and warn when 30s remain

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685849d16ae48332afd93d1d37320dc8