### PR TITLE
Implement PerkPreviewPanel UI

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Assets\Scripts/Game/GameManager.cs" />
     <Compile Include="Assets\Scripts/UI/SelectSquadPanel.cs" />
     <Compile Include="Assets\Scripts/UI/PerkEntryUI.cs" />
+    <Compile Include="Assets\Scripts/UI/PerkSlotUI.cs" />
     <Compile Include="Assets\Scripts/UI/PerkPreviewPanel.cs" />
     <Compile Include="Assets\Scripts/UI/HeroViewerPanel.cs" />
     <Compile Include="Assets\Scripts/UI/PreparationPanel.cs" />

--- a/Assets/Scripts/Game/HeroData.cs
+++ b/Assets/Scripts/Game/HeroData.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -27,6 +28,9 @@ public class HeroData
     public int defenseBlunt;
 
     public float movementSpeed;
+
+    [Header("Passive Perks")]
+    public List<PerkData> passivePerks = new();
 
     public Sprite icon;
     public GameObject modelPrefab;

--- a/Assets/Scripts/Game/PlayerProfileManager.cs
+++ b/Assets/Scripts/Game/PlayerProfileManager.cs
@@ -116,6 +116,9 @@ public class PlayerProfileManager : MonoBehaviour
             movementSpeed = 5f
         };
 
+        // Optionally populate example perks if any exist in Resources
+        defaultHero.passivePerks = new List<PerkData>(Resources.LoadAll<PerkData>(string.Empty));
+
         currentProfile.heroes.Add(defaultHero);
         currentProfile.activeHero = defaultHero;
     }

--- a/Assets/Scripts/UI/PerkPreviewPanel.cs
+++ b/Assets/Scripts/UI/PerkPreviewPanel.cs
@@ -1,29 +1,46 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 /// <summary>
 /// Read-only list showing the hero's passive perks.
 /// </summary>
 public class PerkPreviewPanel : MonoBehaviour
 {
-    public PerkEntryUI entryPrefab;
+    public PerkSlotUI perkSlotPrefab;
     public Transform container;
+    public GameObject noPerksMessage;
+    [Header("Testing")]
+    public List<PerkData> mockPerks = new();
 
     private readonly List<GameObject> created = new();
 
     /// <summary>
     /// Populates the panel with the given perks.
     /// </summary>
-    public void Populate(List<PerkData> perks)
+    public void ShowPerks(List<PerkData> perks)
     {
         Clear();
-        if (perks == null) return;
+        bool hasPerks = perks != null && perks.Count > 0;
+        if (noPerksMessage != null)
+            noPerksMessage.SetActive(!hasPerks);
+        if (!hasPerks)
+            return;
+
         foreach (var perk in perks)
         {
-            var entry = Instantiate(entryPrefab, container);
-            entry.Setup(perk);
-            created.Add(entry.gameObject);
+            var slot = Instantiate(perkSlotPrefab, container);
+            slot.Setup(perk);
+            created.Add(slot.gameObject);
         }
+    }
+
+    /// <summary>
+    /// Loads mock perks assigned from the inspector for testing.
+    /// </summary>
+    public void LoadMockPerks()
+    {
+        ShowPerks(mockPerks);
     }
 
     private void Clear()

--- a/Assets/Scripts/UI/PerkSlotUI.cs
+++ b/Assets/Scripts/UI/PerkSlotUI.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// UI element displaying a single perk's icon and text.
+/// </summary>
+public class PerkSlotUI : MonoBehaviour
+{
+    public Image icon;
+    public Text nameText;
+    public Text descriptionText;
+
+    /// <summary>
+    /// Fills the slot with the perk data.
+    /// </summary>
+    public void Setup(PerkData data)
+    {
+        if (data == null)
+            return;
+        if (icon != null) icon.sprite = data.icon;
+        if (nameText != null) nameText.text = data.perkName;
+        if (descriptionText != null) descriptionText.text = data.description;
+    }
+}

--- a/Assets/Scripts/UI/PreparationPanel.cs
+++ b/Assets/Scripts/UI/PreparationPanel.cs
@@ -52,7 +52,7 @@ public class PreparationPanel : MonoBehaviour
         var hero = PlayerProfileManager.Instance.GetActiveHero();
         heroViewerPanel.LoadHero(hero);
         if (hero != null)
-            perkPreviewPanel.Populate(hero.passivePerks);
+            perkPreviewPanel.ShowPerks(hero.passivePerks);
     }
 
     private void ShowPanel(GameObject target)


### PR DESCRIPTION
## Summary
- show hero passive perks using new PerkPreviewPanel
- add PerkSlotUI helper for each perk entry
- store passive perks in HeroData
- load example perks for the default hero
- hook panel in PreparationPanel

## Testing
- `dotnet build ConquestTactics_prototype.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68584f6245b08332b233edfb7b458c59