### PR TITLE
Add missing Unity meta files for script assets

### DIFF
--- a/Assets/Scripts/Game/BattleManager.cs.meta
+++ b/Assets/Scripts/Game/BattleManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c880a766eb84271861dc199d64eb860
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/BattleResultData.cs.meta
+++ b/Assets/Scripts/Game/BattleResultData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92976b54fd9043d786271a66454c1f99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/BattleTimer.cs.meta
+++ b/Assets/Scripts/Game/BattleTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14c4a1bba44541bdb33b92e5b4ea01eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/CharacterData.cs.meta
+++ b/Assets/Scripts/Game/CharacterData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f072da75e09941d4b01c70410731a5df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/EndBattleHandler.cs.meta
+++ b/Assets/Scripts/Game/EndBattleHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 187a141fe09a4970a4d963507979f688
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/EnemyManager.cs.meta
+++ b/Assets/Scripts/Game/EnemyManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf3d530080f6402a808f5cbea4e612a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/GameManager.cs.meta
+++ b/Assets/Scripts/Game/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 436451c19afb44bf8c0cb6e4fd16e5ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/HeroData.cs.meta
+++ b/Assets/Scripts/Game/HeroData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4396919b5364bc78e4031e56920a656
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/Matchmaker.cs.meta
+++ b/Assets/Scripts/Game/Matchmaker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d61231666f6407d812bbd47535b6eab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/PerkData.cs.meta
+++ b/Assets/Scripts/Game/PerkData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c5a988400ea44ccaad25384d8fc772d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/PlayerProfileData.cs.meta
+++ b/Assets/Scripts/Game/PlayerProfileData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18494408185d468fa64a2d34c726163f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/PlayerProfileManager.cs.meta
+++ b/Assets/Scripts/Game/PlayerProfileManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c51d0f70c20444783bdb6df94dea37c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/SceneDataCarrier.cs.meta
+++ b/Assets/Scripts/Game/SceneDataCarrier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 069cd679cc784033a1bb26a7a2ce6df8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/SceneLoader.cs.meta
+++ b/Assets/Scripts/Game/SceneLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc1805bc84f940df8faaf1ac69e4e0c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/BattleResultsUI.cs.meta
+++ b/Assets/Scripts/UI/BattleResultsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3e75f2dd18a4edfb11363c5f1c7ec14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/CharacterSelectionPanel.cs.meta
+++ b/Assets/Scripts/UI/CharacterSelectionPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51c028bc5dac47efb3cf081b43b68706
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/HeroCardUI.cs.meta
+++ b/Assets/Scripts/UI/HeroCardUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c7e2953fcd74181abadd84a6bacdd65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/HeroCreationModal.cs.meta
+++ b/Assets/Scripts/UI/HeroCreationModal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77c93a880cfa4ce1833e683e14d81251
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/HeroViewerPanel.cs.meta
+++ b/Assets/Scripts/UI/HeroViewerPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cdfbfa88fc84d62aecf047751bec9a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/InBattleHUD.cs.meta
+++ b/Assets/Scripts/UI/InBattleHUD.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66d1daef73cc4ab58eb5163961dcde7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/LoadingScreen.cs.meta
+++ b/Assets/Scripts/UI/LoadingScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cab24e802c564fb28d2023cade19df54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/LoginManager.cs.meta
+++ b/Assets/Scripts/UI/LoginManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c109a63546d4ba58ffaf97512f46aac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/PerkEntryUI.cs.meta
+++ b/Assets/Scripts/UI/PerkEntryUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c16159e210f44dbeb3a308d36fea967e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/PerkPreviewPanel.cs.meta
+++ b/Assets/Scripts/UI/PerkPreviewPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbbede5e42f44669871f9fc37864cef2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/PerkSlotUI.cs.meta
+++ b/Assets/Scripts/UI/PerkSlotUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d47451f747db4710a55a2cb650243c1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/PreparationPanel.cs.meta
+++ b/Assets/Scripts/UI/PreparationPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 287537b0785f47a7b007cdd3ff3fcc6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/SelectSquadPanel.cs.meta
+++ b/Assets/Scripts/UI/SelectSquadPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 977cdbf62d6a4f4e8f6e68ed30ff6b5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add Unity `.meta` files for various scripts in `Assets/Scripts/Game` and `Assets/Scripts/UI`

## Testing
- `find Assets -name '*.cs'` to verify all script files now have matching `.meta`

------
https://chatgpt.com/codex/tasks/task_e_68585c6a0a508332805c197bbc975d10